### PR TITLE
Adds symmetric key management (OpenSSL 3.5 SKEYMGMT) support to the D…

### DIFF
--- a/src/openssl_wrapper/versions/openssl-3.0.12/providers/digicert/rands/digi_drbg_hash.c
+++ b/src/openssl_wrapper/versions/openssl-3.0.12/providers/digicert/rands/digi_drbg_hash.c
@@ -83,6 +83,7 @@ static int digiprov_drbg_hash_instantiate(PROV_DRBG *drbg, const unsigned char *
                                           const unsigned char *nonce, size_t nonce_len,
                                           const unsigned char *pstr, size_t pstr_len)
 {
+#ifndef __ENABLE_DIGICERT_FIPS_MODULE__
     MSTATUS status = OK;
     DP_DRBG_HASH *hash = (DP_DRBG_HASH *)drbg->data;
     NIST_HASH_DRBG_Ctx *pNewCtx = NULL;
@@ -103,7 +104,7 @@ static int digiprov_drbg_hash_instantiate(PROV_DRBG *drbg, const unsigned char *
         hash->pRandCtx = pNewCtx; pNewCtx = NULL;
         return 1;
     }
- 
+#endif
     return 0;
 }
 
@@ -124,6 +125,7 @@ static int digiprov_drbg_hash_reseed(PROV_DRBG *drbg,
                                      const unsigned char *ent, size_t ent_len,
                                      const unsigned char *adin, size_t adin_len)
 {
+#ifndef __ENABLE_DIGICERT_FIPS_MODULE__
     MSTATUS status = OK;
     DP_DRBG_HASH *hash = (DP_DRBG_HASH *)drbg->data;
 
@@ -136,6 +138,9 @@ static int digiprov_drbg_hash_reseed(PROV_DRBG *drbg,
         return 0;
 
     return 1;
+#else
+    return 0;
+#endif
 }
 
 static int digiprov_drbg_hash_reseed_wrapper(void *vdrbg, int prediction_resistance,
@@ -151,6 +156,7 @@ static int digiprov_drbg_hash_generate(PROV_DRBG *drbg,
                                        unsigned char *out, size_t outlen,
                                        const unsigned char *adin, size_t adin_len)
 {
+#ifndef __ENABLE_DIGICERT_FIPS_MODULE__
     MSTATUS status = OK;
     DP_DRBG_HASH *hash = (DP_DRBG_HASH *)drbg->data;
    
@@ -160,6 +166,9 @@ static int digiprov_drbg_hash_generate(PROV_DRBG *drbg,
         return 0;
     
     return 1;
+#else
+    return 0;
+#endif
 }
 
 static int digiprov_drbg_hash_generate_wrapper
@@ -173,6 +182,7 @@ static int digiprov_drbg_hash_generate_wrapper
 
 static int digiprov_drbg_hash_uninstantiate(PROV_DRBG *drbg)
 {
+#ifndef __ENABLE_DIGICERT_FIPS_MODULE__
     MSTATUS status = OK;
     DP_DRBG_HASH *hash = (DP_DRBG_HASH *)drbg->data;
 
@@ -187,6 +197,9 @@ static int digiprov_drbg_hash_uninstantiate(PROV_DRBG *drbg)
         return 0;
 
     return 1;
+#else
+    return 0;
+#endif
 }
 
 static int digiprov_drbg_hash_uninstantiate_wrapper(void *vdrbg)
@@ -202,6 +215,7 @@ static int digiprov_drbg_hash_verify_zeroization(void *vdrbg)
 
 static int digiprov_drbg_hash_new(PROV_DRBG *ctx)
 {
+#ifndef __ENABLE_DIGICERT_FIPS_MODULE__
     MSTATUS status = OK;
     DP_DRBG_HASH *hash = NULL;
 
@@ -222,6 +236,9 @@ static int digiprov_drbg_hash_new(PROV_DRBG *ctx)
     /* Maximum number of bits per request = 2^19  = 2^16 bytes */
     ctx->max_request = 1 << 16;
     return 1;
+#else
+    return 0;
+#endif
 }
 
 static void *digiprov_drbg_hash_new_wrapper(void *provctx, void *parent,
@@ -235,6 +252,7 @@ static void *digiprov_drbg_hash_new_wrapper(void *provctx, void *parent,
 static void digiprov_drbg_hash_free(void *vdrbg)
 {
     PROV_DRBG *drbg = (PROV_DRBG *)vdrbg;
+#ifndef __ENABLE_DIGICERT_FIPS_MODULE__
     DP_DRBG_HASH *hash;
 
     if (NULL != drbg)
@@ -250,7 +268,7 @@ static void digiprov_drbg_hash_free(void *vdrbg)
             (void) DIGI_MEMSET_FREE((ubyte **) &hash, sizeof(*hash));
         }
     }
-
+#endif
     digiprov_rand_drbg_free(drbg);
 }
 

--- a/src/openssl_wrapper/versions/openssl-3.0.12/providers/digicert/test/digiprov_test_main.c
+++ b/src/openssl_wrapper/versions/openssl-3.0.12/providers/digicert/test/digiprov_test_main.c
@@ -536,6 +536,7 @@ test_start:
         ret += test_rand(pLibCtx, "CTR-DRBG", "TDES-CTR");
 
         /* HASH-DRBG with MD4, and MD5 not supported as per RFC */
+#ifndef __ENABLE_DIGICERT_FIPS_MODULE__
         ret += test_rand(pLibCtx, "HASH-DRBG", "SHA-1");
         ret += test_rand(pLibCtx, "HASH-DRBG", "SHA-224");
         ret += test_rand(pLibCtx, "HASH-DRBG", "SHA-256");
@@ -545,7 +546,7 @@ test_start:
         ret += test_rand(pLibCtx, "HASH-DRBG", "SHA3-256");
         ret += test_rand(pLibCtx, "HASH-DRBG", "SHA3-384");
         ret += test_rand(pLibCtx, "HASH-DRBG", "SHA3-512");
-
+#endif
         if (tret == ret)
         {
             printf("rand tests: PASS\n");

--- a/src/openssl_wrapper/versions/openssl-3.0.7/providers/digicert/rands/digi_drbg_hash.c
+++ b/src/openssl_wrapper/versions/openssl-3.0.7/providers/digicert/rands/digi_drbg_hash.c
@@ -83,6 +83,7 @@ static int digiprov_drbg_hash_instantiate(PROV_DRBG *drbg, const unsigned char *
                                           const unsigned char *nonce, size_t nonce_len,
                                           const unsigned char *pstr, size_t pstr_len)
 {
+#ifndef __ENABLE_DIGICERT_FIPS_MODULE__
     MSTATUS status = OK;
     DP_DRBG_HASH *hash = (DP_DRBG_HASH *)drbg->data;
     NIST_HASH_DRBG_Ctx *pNewCtx = NULL;
@@ -103,7 +104,7 @@ static int digiprov_drbg_hash_instantiate(PROV_DRBG *drbg, const unsigned char *
         hash->pRandCtx = pNewCtx; pNewCtx = NULL;
         return 1;
     }
- 
+#endif
     return 0;
 }
 
@@ -124,6 +125,7 @@ static int digiprov_drbg_hash_reseed(PROV_DRBG *drbg,
                                      const unsigned char *ent, size_t ent_len,
                                      const unsigned char *adin, size_t adin_len)
 {
+#ifndef __ENABLE_DIGICERT_FIPS_MODULE__
     MSTATUS status = OK;
     DP_DRBG_HASH *hash = (DP_DRBG_HASH *)drbg->data;
 
@@ -136,6 +138,9 @@ static int digiprov_drbg_hash_reseed(PROV_DRBG *drbg,
         return 0;
 
     return 1;
+#else
+    return 0;
+#endif
 }
 
 static int digiprov_drbg_hash_reseed_wrapper(void *vdrbg, int prediction_resistance,
@@ -151,6 +156,7 @@ static int digiprov_drbg_hash_generate(PROV_DRBG *drbg,
                                        unsigned char *out, size_t outlen,
                                        const unsigned char *adin, size_t adin_len)
 {
+#ifndef __ENABLE_DIGICERT_FIPS_MODULE__
     MSTATUS status = OK;
     DP_DRBG_HASH *hash = (DP_DRBG_HASH *)drbg->data;
    
@@ -160,6 +166,9 @@ static int digiprov_drbg_hash_generate(PROV_DRBG *drbg,
         return 0;
     
     return 1;
+#else
+    return 0;
+#endif
 }
 
 static int digiprov_drbg_hash_generate_wrapper
@@ -173,6 +182,7 @@ static int digiprov_drbg_hash_generate_wrapper
 
 static int digiprov_drbg_hash_uninstantiate(PROV_DRBG *drbg)
 {
+#ifndef __ENABLE_DIGICERT_FIPS_MODULE__
     MSTATUS status = OK;
     DP_DRBG_HASH *hash = (DP_DRBG_HASH *)drbg->data;
 
@@ -187,6 +197,9 @@ static int digiprov_drbg_hash_uninstantiate(PROV_DRBG *drbg)
         return 0;
 
     return 1;
+#else
+    return 0;
+#endif
 }
 
 static int digiprov_drbg_hash_uninstantiate_wrapper(void *vdrbg)
@@ -202,6 +215,7 @@ static int digiprov_drbg_hash_verify_zeroization(void *vdrbg)
 
 static int digiprov_drbg_hash_new(PROV_DRBG *ctx)
 {
+#ifndef __ENABLE_DIGICERT_FIPS_MODULE__
     MSTATUS status = OK;
     DP_DRBG_HASH *hash = NULL;
 
@@ -222,6 +236,9 @@ static int digiprov_drbg_hash_new(PROV_DRBG *ctx)
     /* Maximum number of bits per request = 2^19  = 2^16 bytes */
     ctx->max_request = 1 << 16;
     return 1;
+#else
+    return 0;
+#endif
 }
 
 static void *digiprov_drbg_hash_new_wrapper(void *provctx, void *parent,
@@ -235,6 +252,7 @@ static void *digiprov_drbg_hash_new_wrapper(void *provctx, void *parent,
 static void digiprov_drbg_hash_free(void *vdrbg)
 {
     PROV_DRBG *drbg = (PROV_DRBG *)vdrbg;
+#ifndef __ENABLE_DIGICERT_FIPS_MODULE__
     DP_DRBG_HASH *hash;
 
     if (NULL != drbg)
@@ -250,7 +268,7 @@ static void digiprov_drbg_hash_free(void *vdrbg)
             (void) DIGI_MEMSET_FREE((ubyte **) &hash, sizeof(*hash));
         }
     }
-
+#endif
     digiprov_rand_drbg_free(drbg);
 }
 

--- a/src/openssl_wrapper/versions/openssl-3.0.7/providers/digicert/test/digiprov_test_main.c
+++ b/src/openssl_wrapper/versions/openssl-3.0.7/providers/digicert/test/digiprov_test_main.c
@@ -536,6 +536,7 @@ test_start:
         ret += test_rand(pLibCtx, "CTR-DRBG", "TDES-CTR");
 
         /* HASH-DRBG with MD4, and MD5 not supported as per RFC */
+#ifndef __ENABLE_DIGICERT_FIPS_MODULE__
         ret += test_rand(pLibCtx, "HASH-DRBG", "SHA-1");
         ret += test_rand(pLibCtx, "HASH-DRBG", "SHA-224");
         ret += test_rand(pLibCtx, "HASH-DRBG", "SHA-256");
@@ -545,7 +546,7 @@ test_start:
         ret += test_rand(pLibCtx, "HASH-DRBG", "SHA3-256");
         ret += test_rand(pLibCtx, "HASH-DRBG", "SHA3-384");
         ret += test_rand(pLibCtx, "HASH-DRBG", "SHA3-512");
-
+#endif
         if (tret == ret)
         {
             printf("rand tests: PASS\n");

--- a/src/openssl_wrapper/versions/openssl-3.5.0/providers/digicert/build.info
+++ b/src/openssl_wrapper/versions/openssl-3.5.0/providers/digicert/build.info
@@ -1,1 +1,1 @@
-SUBDIRS=asymciphers ciphers common digests encode_decode exchange kdfs kem keymgmt macs rands signature
+SUBDIRS=asymciphers ciphers common digests encode_decode exchange kdfs kem keymgmt macs rands signature skeymgmt

--- a/src/openssl_wrapper/versions/openssl-3.5.0/providers/digicert/ciphers/digi_ciphercommon.c
+++ b/src/openssl_wrapper/versions/openssl-3.5.0/providers/digicert/ciphers/digi_ciphercommon.c
@@ -63,6 +63,8 @@
 #include "prov/providercommon.h"
 
 #include "digiprov.h"
+#include "internal/skey.h"
+#include "crypto/types.h"
 
 size_t digiprov_cipher_fillblock(unsigned char *buf, size_t *buflen, size_t blocksize,
                                  const unsigned char **in, size_t *inlen);
@@ -1212,4 +1214,26 @@ void *digiprov_cipher_generic_dupctx(void *vctx)
     }
  
     return (void *) pRet;
+}
+
+int digiprov_cipher_generic_skey_einit(void *vctx, void *skeydata,
+                                       const unsigned char *iv, size_t ivlen,
+                                       const OSSL_PARAM params[])
+{
+    PROV_SKEY *key = skeydata;
+
+    return cipher_generic_init_internal((DP_CIPHER_CTX *)vctx,
+                                        key->data, key->length,
+                                        iv, ivlen, params, 1);
+}
+
+int digiprov_cipher_generic_skey_dinit(void *vctx, void *skeydata,
+                                       const unsigned char *iv, size_t ivlen,
+                                       const OSSL_PARAM params[])
+{
+    PROV_SKEY *key = skeydata;
+
+    return cipher_generic_init_internal((DP_CIPHER_CTX *)vctx,
+                                        key->data, key->length,
+                                        iv, ivlen, params, 0);
 }

--- a/src/openssl_wrapper/versions/openssl-3.5.0/providers/digicert/ciphers/digi_ciphercommon.h
+++ b/src/openssl_wrapper/versions/openssl-3.5.0/providers/digicert/ciphers/digi_ciphercommon.h
@@ -233,6 +233,8 @@ OSSL_FUNC_cipher_set_ctx_params_fn digiprov_cipher_var_keylen_set_ctx_params;
 OSSL_FUNC_cipher_settable_ctx_params_fn digiprov_cipher_var_keylen_settable_ctx_params;
 OSSL_FUNC_cipher_gettable_ctx_params_fn digiprov_cipher_aead_gettable_ctx_params;
 OSSL_FUNC_cipher_settable_ctx_params_fn digiprov_cipher_aead_settable_ctx_params;
+OSSL_FUNC_cipher_encrypt_skey_init_fn digiprov_cipher_generic_skey_einit;
+OSSL_FUNC_cipher_decrypt_skey_init_fn digiprov_cipher_generic_skey_dinit;
 
 int digiprov_cipher_generic_get_params(OSSL_PARAM params[], unsigned int md,
                                    uint64_t flags,
@@ -279,6 +281,8 @@ const OSSL_DISPATCH digiprov_##alg##kbits##lcmode##_functions[] = {            \
       (void (*)(void))digiprov_cipher_generic_gettable_ctx_params },               \
     { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,                                    \
      (void (*)(void))digiprov_cipher_generic_settable_ctx_params },                \
+    { OSSL_FUNC_CIPHER_ENCRYPT_SKEY_INIT, (void (*)(void))digiprov_cipher_generic_skey_einit }, \
+    { OSSL_FUNC_CIPHER_DECRYPT_SKEY_INIT, (void (*)(void))digiprov_cipher_generic_skey_dinit }, \
     { 0, NULL }                                                                \
 };
 
@@ -306,6 +310,8 @@ const OSSL_DISPATCH digiprov_##alg##kbits##lcmode##_functions[] = {             
       (void (*)(void))digiprov_cipher_generic_gettable_ctx_params },               \
     { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,                                    \
      (void (*)(void))digiprov_cipher_var_keylen_settable_ctx_params },             \
+    { OSSL_FUNC_CIPHER_ENCRYPT_SKEY_INIT, (void (*)(void))digiprov_cipher_generic_skey_einit }, \
+    { OSSL_FUNC_CIPHER_DECRYPT_SKEY_INIT, (void (*)(void))digiprov_cipher_generic_skey_dinit }, \
     { 0, NULL }                                                                \
 };
 

--- a/src/openssl_wrapper/versions/openssl-3.5.0/providers/digicert/include/digiprov.h
+++ b/src/openssl_wrapper/versions/openssl-3.5.0/providers/digicert/include/digiprov.h
@@ -154,6 +154,9 @@ extern const OSSL_DISPATCH digiprov_ecdh_keyexch_functions[];
 extern const OSSL_DISPATCH digiprov_x25519_keyexch_functions[];
 extern const OSSL_DISPATCH digiprov_x448_keyexch_functions[];
 
+extern const OSSL_DISPATCH digiprov_aes_skeymgmt_functions[];
+extern const OSSL_DISPATCH digiprov_generic_skeymgmt_functions[];
+
 extern const OSSL_DISPATCH digiprov_pqc_kem_functions[];
 extern const OSSL_DISPATCH digiprov_pqc_mlx_kem_functions[];
 

--- a/src/openssl_wrapper/versions/openssl-3.5.0/providers/digicert/keymgmt/digi_mlx_kmgmt.c
+++ b/src/openssl_wrapper/versions/openssl-3.5.0/providers/digicert/keymgmt/digi_mlx_kmgmt.c
@@ -794,7 +794,7 @@ static const OSSL_PARAM *digi_mlx_kem_gen_settable_params(ossl_unused void *vgct
 {
     static OSSL_PARAM settable[] = 
     {
-        OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_PROPERTIES, NULL, 0),
+        OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_PROPERTIES, NULL, 0),
         OSSL_PARAM_END
     };
 

--- a/src/openssl_wrapper/versions/openssl-3.5.0/providers/digicert/rands/digi_drbg_hash.c
+++ b/src/openssl_wrapper/versions/openssl-3.5.0/providers/digicert/rands/digi_drbg_hash.c
@@ -3,14 +3,17 @@
  *
  * NIST DRBG HASH implementations for OSSL 3.0 provider
  *
- * Copyright 2026 DigiCert Project Authors. All Rights Reserved.
+ * Copyright 2026 DigiCert, Inc. All Rights Reserved.
  *
- * DigiCert® TrustCore and TrustEdge are licensed under a dual-license model:
- * - **Open Source License**: GNU AGPL v3. See: https://github.com/digicert/trustcore-test/blob/main/LICENSE
- * - **Commercial License**: Available under DigiCert’s Master Services Agreement. See: https://github.com/digicert/trustcore-test/blob/main/LICENSE_COMMERCIAL.txt
- *   or https://www.digicert.com/master-services-agreement/
+ * DigiCert® TrustCore SDK and TrustEdge are licensed under a dual-license model:
  *
- * For commercial licensing, contact DigiCert at sales@digicert.com.*
+ * 1. **Open Source License**: GNU Affero General Public License v3.0 (AGPL v3).
+ * See: https://github.com/digicert/trustcore/blob/main/LICENSE.md
+ * 2. **Commercial License**: Available under DigiCert's Master Services Agreement.
+ * See: https://www.digicert.com/master-services-agreement/
+ *
+ * *Use of TrustCore SDK or TrustEdge outside the scope of AGPL v3 requires a commercial license.*
+ * *Contact DigiCert at sales@digicert.com for more details.*
  *
  */
 /*
@@ -88,6 +91,7 @@ static int digiprov_drbg_hash_instantiate(PROV_DRBG *drbg, const unsigned char *
                                           const unsigned char *nonce, size_t nonce_len,
                                           const unsigned char *pstr, size_t pstr_len)
 {
+#ifndef __ENABLE_DIGICERT_FIPS_MODULE__
     MSTATUS status = OK;
     DP_DRBG_HASH *hash = (DP_DRBG_HASH *)drbg->data;
     NIST_HASH_DRBG_Ctx *pNewCtx = NULL;
@@ -108,7 +112,7 @@ static int digiprov_drbg_hash_instantiate(PROV_DRBG *drbg, const unsigned char *
         hash->pRandCtx = pNewCtx; pNewCtx = NULL;
         return 1;
     }
- 
+#endif
     return 0;
 }
 
@@ -129,6 +133,7 @@ static int digiprov_drbg_hash_reseed(PROV_DRBG *drbg,
                                      const unsigned char *ent, size_t ent_len,
                                      const unsigned char *adin, size_t adin_len)
 {
+#ifndef __ENABLE_DIGICERT_FIPS_MODULE__
     MSTATUS status = OK;
     DP_DRBG_HASH *hash = (DP_DRBG_HASH *)drbg->data;
 
@@ -141,6 +146,9 @@ static int digiprov_drbg_hash_reseed(PROV_DRBG *drbg,
         return 0;
 
     return 1;
+#else
+    return 0;
+#endif
 }
 
 static int digiprov_drbg_hash_reseed_wrapper(void *vdrbg, int prediction_resistance,
@@ -156,6 +164,7 @@ static int digiprov_drbg_hash_generate(PROV_DRBG *drbg,
                                        unsigned char *out, size_t outlen,
                                        const unsigned char *adin, size_t adin_len)
 {
+#ifndef __ENABLE_DIGICERT_FIPS_MODULE__
     MSTATUS status = OK;
     DP_DRBG_HASH *hash = (DP_DRBG_HASH *)drbg->data;
    
@@ -165,6 +174,9 @@ static int digiprov_drbg_hash_generate(PROV_DRBG *drbg,
         return 0;
     
     return 1;
+#else
+    return 0;
+#endif
 }
 
 static int digiprov_drbg_hash_generate_wrapper
@@ -178,6 +190,7 @@ static int digiprov_drbg_hash_generate_wrapper
 
 static int digiprov_drbg_hash_uninstantiate(PROV_DRBG *drbg)
 {
+#ifndef __ENABLE_DIGICERT_FIPS_MODULE__
     MSTATUS status = OK;
     DP_DRBG_HASH *hash = (DP_DRBG_HASH *)drbg->data;
 
@@ -192,6 +205,9 @@ static int digiprov_drbg_hash_uninstantiate(PROV_DRBG *drbg)
         return 0;
 
     return 1;
+#else
+    return 0;
+#endif
 }
 
 static int digiprov_drbg_hash_uninstantiate_wrapper(void *vdrbg)
@@ -207,6 +223,7 @@ static int digiprov_drbg_hash_verify_zeroization(void *vdrbg)
 
 static int digiprov_drbg_hash_new(PROV_DRBG *ctx)
 {
+#ifndef __ENABLE_DIGICERT_FIPS_MODULE__
     MSTATUS status = OK;
     DP_DRBG_HASH *hash = NULL;
 
@@ -227,6 +244,9 @@ static int digiprov_drbg_hash_new(PROV_DRBG *ctx)
     /* Maximum number of bits per request = 2^19  = 2^16 bytes */
     ctx->max_request = 1 << 16;
     return 1;
+#else
+    return 0;
+#endif
 }
 
 static void *digiprov_drbg_hash_new_wrapper(void *provctx, void *parent,
@@ -240,6 +260,7 @@ static void *digiprov_drbg_hash_new_wrapper(void *provctx, void *parent,
 static void digiprov_drbg_hash_free(void *vdrbg)
 {
     PROV_DRBG *drbg = (PROV_DRBG *)vdrbg;
+#ifndef __ENABLE_DIGICERT_FIPS_MODULE__
     DP_DRBG_HASH *hash;
 
     if (NULL != drbg)
@@ -255,7 +276,7 @@ static void digiprov_drbg_hash_free(void *vdrbg)
             (void) DIGI_MEMSET_FREE((ubyte **) &hash, sizeof(*hash));
         }
     }
-
+#endif
     digiprov_rand_drbg_free(drbg);
 }
 

--- a/src/openssl_wrapper/versions/openssl-3.5.0/providers/digicert/skeymgmt/build.info
+++ b/src/openssl_wrapper/versions/openssl-3.5.0/providers/digicert/skeymgmt/build.info
@@ -1,0 +1,8 @@
+# We make separate GOAL variables for each algorithm, to make it easy to
+# switch each to the Legacy provider when needed.
+
+$AES_GOAL=../../libdigiprov.a
+$GENERIC_GOAL=../../libdigiprov.a
+
+SOURCE[$AES_GOAL]=digi_aes_skmgmt.c
+SOURCE[$GENERIC_GOAL]=digi_generic.c

--- a/src/openssl_wrapper/versions/openssl-3.5.0/providers/digicert/skeymgmt/digi_aes_skmgmt.c
+++ b/src/openssl_wrapper/versions/openssl-3.5.0/providers/digicert/skeymgmt/digi_aes_skmgmt.c
@@ -1,0 +1,86 @@
+/*
+ * digi_aes_skmgmt.c
+ *
+ * AES key management implementations for OSSL 3.5 provider ADAPTED FROM OPENSSL CODE
+ *
+ * Copyright 2026 DigiCert Project Authors. All Rights Reserved.
+ *
+ * DigiCert® TrustCore and TrustEdge are licensed under a dual-license model:
+ * - **Open Source License**: GNU AGPL v3. See: https://github.com/digicert/trustcore-test/blob/main/LICENSE
+ * - **Commercial License**: Available under DigiCert’s Master Services Agreement. See: https://github.com/digicert/trustcore-test/blob/main/LICENSE_COMMERCIAL.txt
+ *   or https://www.digicert.com/master-services-agreement/
+ *
+ * For commercial licensing, contact DigiCert at sales@digicert.com.*
+ *
+ */
+/*
+ * Copyright 2025 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "../../../src/common/moptions.h"
+#include "../../../src/common/mtypes.h"
+#include "../../../src/common/mdefs.h"
+#include "../../../src/common/merrors.h"
+#include "../../../src/common/mstdlib.h"
+
+#include "mocana_glue.h"
+#include "digicert_common.h"
+
+#ifdef CONTEXT
+#undef CONTEXT
+#endif
+
+#ifdef BOOLEAN
+#undef BOOLEAN
+#endif
+
+#include "digiprov.h"
+#include "openssl/core_dispatch.h"
+#include "openssl/core_names.h"
+#include "crypto/types.h"
+#include "internal/skey.h"
+#include "prov/provider_ctx.h"
+#include "digi_skeymgmt_lcl.h"
+
+static OSSL_FUNC_skeymgmt_import_fn digi_aes_import;
+static OSSL_FUNC_skeymgmt_export_fn digi_aes_export;
+
+static void *digi_aes_import(void *provctx, int selection, const OSSL_PARAM params[])
+{
+    PROV_SKEY *aes = digi_generic_import(provctx, selection, params);
+
+    if (aes == NULL)
+        return NULL;
+
+    if (aes->length != 16 && aes->length != 24 && aes->length != 32 && aes->length != 64) /* aes-xts-256 is two 32 byte keys */ 
+    {
+        digi_generic_free(aes);
+        return NULL;
+    }
+    aes->type = SKEY_TYPE_AES;
+
+    return aes;
+}
+
+static int digi_aes_export(void *keydata, int selection, OSSL_CALLBACK *param_callback, void *cbarg)
+{
+    PROV_SKEY *aes = keydata;
+
+    if (aes->type != SKEY_TYPE_AES)
+        return 0;
+
+    return digi_generic_export(keydata, selection, param_callback, cbarg);
+}
+
+const OSSL_DISPATCH digiprov_aes_skeymgmt_functions[] = 
+{
+    { OSSL_FUNC_SKEYMGMT_FREE, (void (*)(void))digi_generic_free },
+    { OSSL_FUNC_SKEYMGMT_IMPORT, (void (*)(void))digi_aes_import },
+    { OSSL_FUNC_SKEYMGMT_EXPORT, (void (*)(void))digi_aes_export },
+    OSSL_DISPATCH_END
+};

--- a/src/openssl_wrapper/versions/openssl-3.5.0/providers/digicert/skeymgmt/digi_generic.c
+++ b/src/openssl_wrapper/versions/openssl-3.5.0/providers/digicert/skeymgmt/digi_generic.c
@@ -1,0 +1,125 @@
+/*
+ * digi_generic.c
+ *
+ * Generic symmetric key management implementations for OSSL 3.5 provider ADAPTED FROM OPENSSL CODE
+ *
+ * Copyright 2026 DigiCert Project Authors. All Rights Reserved.
+ *
+ * DigiCert® TrustCore and TrustEdge are licensed under a dual-license model:
+ * - **Open Source License**: GNU AGPL v3. See: https://github.com/digicert/trustcore-test/blob/main/LICENSE
+ * - **Commercial License**: Available under DigiCert’s Master Services Agreement. See: https://github.com/digicert/trustcore-test/blob/main/LICENSE_COMMERCIAL.txt
+ *   or https://www.digicert.com/master-services-agreement/
+ *
+ * For commercial licensing, contact DigiCert at sales@digicert.com.*
+ *
+ */
+/*
+ * Copyright 2025 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "../../../src/common/moptions.h"
+#include "../../../src/common/mtypes.h"
+#include "../../../src/common/mdefs.h"
+#include "../../../src/common/merrors.h"
+#include "../../../src/common/mstdlib.h"
+
+#include "mocana_glue.h"
+#include "digicert_common.h"
+
+#ifdef CONTEXT
+#undef CONTEXT
+#endif
+
+#ifdef BOOLEAN
+#undef BOOLEAN
+#endif
+
+#include "digiprov.h"
+#include "openssl/core_dispatch.h"
+#include "openssl/core_names.h"
+#include "crypto/types.h"
+#include "internal/skey.h"
+#include "prov/provider_ctx.h"
+#include "digi_skeymgmt_lcl.h"
+
+void digi_generic_free(void *keydata)
+{
+    PROV_SKEY *generic = keydata;
+
+    if (generic == NULL)
+        return;
+
+    if (NULL != generic->data)
+    {
+        (void) DIGI_MEMSET_FREE(&generic->data, generic->length);
+        generic->length = 0;
+    }
+    
+    (void) DIGI_FREE((void **) &generic);
+}
+
+void *digi_generic_import(void *provctx, int selection, const OSSL_PARAM params[])
+{
+    MSTATUS status;
+    OSSL_LIB_CTX *libctx = PROV_LIBCTX_OF(provctx);
+    const OSSL_PARAM *raw_bytes;
+    PROV_SKEY *generic = NULL;
+    
+    if (!digiprov_is_running())
+        return NULL;
+
+    if ((selection & OSSL_SKEYMGMT_SELECT_SECRET_KEY) == 0)
+        return NULL;
+
+    raw_bytes = OSSL_PARAM_locate_const(params, OSSL_SKEY_PARAM_RAW_BYTES);
+    if (raw_bytes == NULL)
+        return NULL;
+
+    status = DIGI_CALLOC((void **) &generic, 1, sizeof(PROV_SKEY));
+    if (OK != status)
+        return NULL;
+
+    generic->libctx = libctx;
+    generic->type = SKEY_TYPE_GENERIC;
+
+    status = DIGI_MALLOC_MEMCPY((void **) &generic->data, raw_bytes->data_size, (void *) raw_bytes->data, raw_bytes->data_size);
+    if (OK != status)
+    {
+        (void) DIGI_FREE((void **) &generic);
+        return NULL;
+    }
+    generic->length = raw_bytes->data_size;
+    return generic;
+}
+
+int digi_generic_export(void *keydata, int selection, OSSL_CALLBACK *param_callback, void *cbarg)
+{
+    PROV_SKEY *gen = keydata;
+    OSSL_PARAM params[2];
+
+    if (!digiprov_is_running() || gen == NULL)
+        return 0;
+
+    /* If we use generic SKEYMGMT as a "base class", we shouldn't check the type */
+    if ((selection & OSSL_SKEYMGMT_SELECT_SECRET_KEY) == 0)
+        return 0;
+
+    params[0] = OSSL_PARAM_construct_octet_string(OSSL_SKEY_PARAM_RAW_BYTES,
+                                                  gen->data, gen->length);
+    params[1] = OSSL_PARAM_construct_end();
+
+    return param_callback(params, cbarg);
+}
+
+const OSSL_DISPATCH digiprov_generic_skeymgmt_functions[] = 
+{
+    { OSSL_FUNC_SKEYMGMT_FREE, (void (*)(void))digi_generic_free },
+    { OSSL_FUNC_SKEYMGMT_IMPORT, (void (*)(void))digi_generic_import },
+    { OSSL_FUNC_SKEYMGMT_EXPORT, (void (*)(void))digi_generic_export },
+    OSSL_DISPATCH_END
+};

--- a/src/openssl_wrapper/versions/openssl-3.5.0/providers/digicert/skeymgmt/digi_skeymgmt_lcl.h
+++ b/src/openssl_wrapper/versions/openssl-3.5.0/providers/digicert/skeymgmt/digi_skeymgmt_lcl.h
@@ -1,0 +1,34 @@
+/*
+ * digi_skeymgmt_lcl.h
+ *
+ * Symmetric Key Management header for OSSL 3.5 provider ADAPTED FROM OPENSSL CODE
+ *
+ * Copyright 2026 DigiCert Project Authors. All Rights Reserved.
+ *
+ * DigiCert® TrustCore and TrustEdge are licensed under a dual-license model:
+ * - **Open Source License**: GNU AGPL v3. See: https://github.com/digicert/trustcore-test/blob/main/LICENSE
+ * - **Commercial License**: Available under DigiCert’s Master Services Agreement. See: https://github.com/digicert/trustcore-test/blob/main/LICENSE_COMMERCIAL.txt
+ *   or https://www.digicert.com/master-services-agreement/
+ *
+ * For commercial licensing, contact DigiCert at sales@digicert.com.*
+ *
+ */
+/*
+ * Copyright 2025 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef DIGI_SKEYMGMT_LCL_H
+# define DIGI_SKEYMGMT_LCL_H
+# pragma once
+# include <openssl/core_dispatch.h>
+
+OSSL_FUNC_skeymgmt_import_fn digi_generic_import;
+OSSL_FUNC_skeymgmt_export_fn digi_generic_export;
+OSSL_FUNC_skeymgmt_free_fn digi_generic_free;
+
+#endif

--- a/src/openssl_wrapper/versions/openssl-3.5.0/providers/digicert/test/digiprov_test_main.c
+++ b/src/openssl_wrapper/versions/openssl-3.5.0/providers/digicert/test/digiprov_test_main.c
@@ -43,6 +43,7 @@ int test_digest(OSSL_LIB_CTX *pLibCtx, ubyte hashType);
 int test_aes(OSSL_LIB_CTX *pLibCtx, char *pAlgoStr);
 int test_cipher(OSSL_LIB_CTX *pLibCtx, char *pAlgoStr);
 int test_cipher_aead(OSSL_LIB_CTX *pLibCtx, char *pAlgoStr);
+int test_cipher_skey(OSSL_LIB_CTX *pLibCtx, char *pAlgoStr);
 int test_rsa_sign(OSSL_LIB_CTX *pLibCtx, int bits, byteBoolean isPss);
 int test_rsa_sign_pem(OSSL_LIB_CTX *pLibCtx, char *pPemFile, byteBoolean isPss);
 int test_rsa_enc_dec_pem(OSSL_LIB_CTX *pLibCtx, char *pPemFile, char *pw);
@@ -325,6 +326,43 @@ test_start:
 
         ret += test_cipher_aead(pLibCtx, "ChaCha20-Poly1305");
 
+        /* skey tests */
+        ret += test_cipher_skey(pLibCtx, "AES-128-CBC");
+        ret += test_cipher_skey(pLibCtx, "AES-192-CBC");
+        ret += test_cipher_skey(pLibCtx, "AES-256-CBC");
+
+        ret += test_cipher_skey(pLibCtx, "AES-128-ECB");
+        ret += test_cipher_skey(pLibCtx, "AES-192-ECB");
+        ret += test_cipher_skey(pLibCtx, "AES-256-ECB");
+
+        ret += test_cipher_skey(pLibCtx, "AES-128-OFB");
+        ret += test_cipher_skey(pLibCtx, "AES-192-OFB");
+        ret += test_cipher_skey(pLibCtx, "AES-256-OFB");
+
+        ret += test_cipher_skey(pLibCtx, "AES-128-CFB");
+        ret += test_cipher_skey(pLibCtx, "AES-192-CFB");
+        ret += test_cipher_skey(pLibCtx, "AES-256-CFB");
+
+        ret += test_cipher_skey(pLibCtx, "AES-128-CTR");
+        ret += test_cipher_skey(pLibCtx, "AES-192-CTR");
+        ret += test_cipher_skey(pLibCtx, "AES-256-CTR");
+        ret += test_cipher_skey(pLibCtx, "AES-128-XTS");
+        ret += test_cipher_skey(pLibCtx, "AES-256-XTS");
+
+        ret += test_cipher_skey(pLibCtx, "DES-EDE3-ECB");
+        ret += test_cipher_skey(pLibCtx, "DES-EDE3-CBC");
+
+        ret += test_cipher_skey(pLibCtx, "DES-ECB");
+        ret += test_cipher_skey(pLibCtx, "DES-CBC");
+
+        /* ret += test_cipher(pLibCtx, "BF-ECB"); not supported */
+        ret += test_cipher_skey(pLibCtx, "BF-CBC");
+
+        ret += test_cipher_skey(pLibCtx, "RC4");
+        ret += test_cipher_skey(pLibCtx, "RC4-40");
+
+        /* rc5 and chacha not supported */
+
         if (tret == ret)
         {
             printf("cipher tests: PASS\n");
@@ -538,6 +576,7 @@ test_start:
         ret += test_rand(pLibCtx, "CTR-DRBG", "TDES-CTR");
 
         /* HASH-DRBG with MD4, and MD5 not supported as per RFC */
+#ifndef __ENABLE_DIGICERT_FIPS_MODULE__
         ret += test_rand(pLibCtx, "HASH-DRBG", "SHA-1");
         ret += test_rand(pLibCtx, "HASH-DRBG", "SHA-224");
         ret += test_rand(pLibCtx, "HASH-DRBG", "SHA-256");
@@ -547,7 +586,7 @@ test_start:
         ret += test_rand(pLibCtx, "HASH-DRBG", "SHA3-256");
         ret += test_rand(pLibCtx, "HASH-DRBG", "SHA3-384");
         ret += test_rand(pLibCtx, "HASH-DRBG", "SHA3-512");
-
+#endif
         if (tret == ret)
         {
             printf("rand tests: PASS\n");

--- a/src/openssl_wrapper/versions/openssl-3.5.0/providers/digicert/test/test_cipher.c
+++ b/src/openssl_wrapper/versions/openssl-3.5.0/providers/digicert/test/test_cipher.c
@@ -28,6 +28,8 @@
 
 #include "openssl/evp.h"
 #include "openssl/provider.h"
+#include "openssl/core_names.h"
+#include "prov/names.h"
 
 #include <stdio.h>
 
@@ -542,6 +544,314 @@ exit:
     if (NULL != pCipher)
     {
         EVP_CIPHER_free(pCipher);
+    }
+
+    return ret;
+}
+
+/* structure to hold exported symmetric keys */
+typedef struct _keyBuf
+{
+    char key[64]; /* big enough for any key */
+    size_t keyLen;
+} KeyBuf;
+
+/* Callback for the export sym key to write to the above structure */
+static int export_callback(const OSSL_PARAM params[], void *arg) 
+{
+    KeyBuf *pKeyBuf = (KeyBuf *) arg;
+    const OSSL_PARAM *p = OSSL_PARAM_locate_const(params, OSSL_SKEY_PARAM_RAW_BYTES);
+    if (p != NULL && p->data_type == OSSL_PARAM_OCTET_STRING)
+    {
+        (void) DIGI_MEMCPY(pKeyBuf->key, p->data, p->data_size);
+        pKeyBuf->keyLen = p->data_size;
+    }
+    else
+    {
+        return 0;
+    }
+
+    return 1;
+}
+
+int test_cipher_skey(OSSL_LIB_CTX *pLibCtx, char *pAlgoStr)
+{
+    MSTATUS status = ERR_GENERAL;
+    int ret = 1;
+    EVP_SKEY *pKey = NULL;
+    EVP_SKEY *pKey2 = NULL;
+    unsigned char key[64] = {0}; /* big enough for all ciphers */ 
+    size_t keyLen = 16; /* default */
+    unsigned char iv[16] = {0};  /* big enough for all ciphers */
+    unsigned char *pIv = (unsigned char *) &iv;
+    size_t ivLen = 16; /* default */
+    KeyBuf keyBuf = {0};         /* for exported key test */
+    unsigned char plaintext[32] = {0};
+    unsigned char ciphertext[48] = {0};
+    unsigned char decryptedtext[48] = {0};
+    int decryptedtext_len = 0, ciphertext_len = 0, plaintext_len = 0;
+    int len = 0;
+    EVP_CIPHER_CTX *ctx = NULL;
+    EVP_CIPHER *pCipher = NULL;
+    sbyte4 cmp = 1;
+    size_t i = 0;
+    char *pGeneric = PROV_NAMES_GENERIC;
+    char *pAes = PROV_NAMES_AES;
+    char *pProvName = pAes;
+
+    if (0 == DIGI_STRCMP(pAlgoStr, "AES-128-ECB"))
+    {
+        pIv = NULL;
+        ivLen = 0;
+    }
+    else if (0 == DIGI_STRCMP(pAlgoStr, "AES-192-ECB"))
+    {
+        pIv = NULL;
+        ivLen = 0;
+        keyLen = 192/8;
+    }
+    else if (0 == DIGI_STRCMP(pAlgoStr, "AES-256-ECB"))
+    {
+        pIv = NULL;
+        ivLen = 0;
+        keyLen = 256/8;  
+    }
+    else if (0 == DIGI_STRCMP(pAlgoStr, "AES-192-CBC"))
+    {
+        keyLen = 192/8;
+    }
+    else if (0 == DIGI_STRCMP(pAlgoStr, "AES-256-CBC"))
+    {
+        keyLen = 256/8;  
+    }
+    else if (0 == DIGI_STRCMP(pAlgoStr, "AES-192-OFB"))
+    {
+        keyLen = 192/8;
+    }
+    else if (0 == DIGI_STRCMP(pAlgoStr, "AES-256-OFB"))
+    {
+        keyLen = 256/8;  
+    }
+    else if (0 == DIGI_STRCMP(pAlgoStr, "AES-192-CFB"))
+    {
+        keyLen = 192/8;
+    }
+    else if (0 == DIGI_STRCMP(pAlgoStr, "AES-256-CFB"))
+    {
+        keyLen = 256/8;  
+    }
+    else if (0 == DIGI_STRCMP(pAlgoStr, "AES-192-CTR"))
+    {
+        keyLen = 192/8;
+    }
+    else if (0 == DIGI_STRCMP(pAlgoStr, "AES-256-CTR"))
+    {
+        keyLen = 256/8;
+    }
+    else if (0 == DIGI_STRCMP(pAlgoStr, "AES-128-XTS"))
+    {   /* XTS uses 2 keys, keyLen is double the AES key size */
+        keyLen = 256/8;
+    }
+    else if (0 == DIGI_STRCMP(pAlgoStr, "AES-256-XTS"))
+    {
+        keyLen = 512/8;
+    }
+    else if (0 == DIGI_STRCMP(pAlgoStr, "DES-EDE3-ECB"))
+    {
+        pIv = NULL;
+        ivLen = 0;
+        keyLen = 192/8;
+        pProvName = pGeneric;
+    }
+    else if (0 == DIGI_STRCMP(pAlgoStr, "DES-EDE3-CBC"))
+    {
+        keyLen = 192/8;
+        ivLen = 8;
+        pProvName = pGeneric;
+    }
+    else if (0 == DIGI_STRCMP(pAlgoStr, "DES-ECB"))
+    {
+        pIv = NULL;
+        ivLen = 0;
+        keyLen = 64/8;
+        pProvName = pGeneric;
+    }
+    else if (0 == DIGI_STRCMP(pAlgoStr, "DES-CBC"))
+    {
+        keyLen = 64/8;
+        ivLen = 8;
+        pProvName = pGeneric;
+    }
+    else if (0 == DIGI_STRCMP(pAlgoStr, "BF-ECB"))
+    {
+        pIv = NULL;
+        ivLen = 0;
+        keyLen = 128/8;
+        pProvName = pGeneric;
+    }
+    else if (0 == DIGI_STRCMP(pAlgoStr, "BF-CBC"))
+    {
+        keyLen = 128/8;
+        ivLen = 8;
+        pProvName = pGeneric;
+    }
+    else if (0 == DIGI_STRCMP(pAlgoStr, "RC4"))
+    {
+        pIv = NULL;
+        ivLen = 0;
+        keyLen = 128/8;
+        pProvName = pGeneric;
+    }
+    else if (0 == DIGI_STRCMP(pAlgoStr, "RC4-40"))
+    {
+        pIv = NULL;
+        ivLen = 0;
+        keyLen = 40/8;
+        pProvName = pGeneric;
+    }
+
+    for (i = 0; i < keyLen; i++)
+    {
+        key[i] = (ubyte)(i+2 & 0xff);
+    }
+
+    plaintext_len = 32;
+    for (i = 0; i < plaintext_len; i++)
+    {
+        plaintext[i] = i+10;
+    }
+
+    for (i = 0; i < ivLen; i++)
+    {
+        iv[i] = i+1;
+    }
+
+    /* Create a new sym key */
+    pKey = EVP_SKEY_import_raw_key(pLibCtx, pProvName, key, keyLen, NULL);
+    if (NULL == pKey)
+    {
+        printf("ERROR EVP_SKEY_import_raw_key\n");
+        goto exit;        
+    }
+
+    /* export it for later use on decryption */
+    if (1 != EVP_SKEY_export(pKey, OSSL_SKEYMGMT_SELECT_SECRET_KEY, export_callback, (void *) &keyBuf))
+    {
+        printf("ERROR EVP_SKEY_export\n");
+        goto exit;
+    }
+
+    /* Create and initialise the context */
+    if(!(ctx = EVP_CIPHER_CTX_new()))
+    {
+        printf("ERROR EVP_CIPHER_CTX_new\n");
+        goto exit;
+    }
+
+    pCipher = EVP_CIPHER_fetch(pLibCtx, pAlgoStr, NULL);
+#if defined(__ENABLE_DIGICERT_FIPS_MODULE__)
+    if ( (1 == EVP_default_properties_is_fips_enabled(NULL)) &&
+         ((0 == DIGI_STRCMP(pAlgoStr, "DES-ECB")) ||
+          (0 == DIGI_STRCMP(pAlgoStr, "DES-CBC"))) )
+    {
+        if (NULL != pCipher)
+        {
+            printf("ERROR EVP_CIPHER_fetch FIPS expected failure\n");
+        }
+        else
+        {
+            ret = 0;
+        }
+        goto exit;
+    }
+#endif
+    if (NULL == pCipher)
+    {
+        printf("ERROR EVP_CIPHER_fetch\n");
+        goto exit;
+    }
+
+    if (1 != EVP_CipherInit_SKEY(ctx, pCipher, pKey, pIv, ivLen, 1, NULL))
+    {
+        printf("ERROR EVP_CipherInit_SKEY\n");
+        goto exit;
+    }
+
+    if(1 != EVP_EncryptUpdate(ctx, ciphertext, &len, plaintext, plaintext_len))
+    {
+        printf("ERROR EVP_EncryptUpdate\n");
+        goto exit;
+    }
+    ciphertext_len = len;
+
+    if(1 != EVP_EncryptFinal_ex(ctx, ciphertext + len, &len))
+    {
+        printf("ERROR EVP_EncryptFinal_ex\n");
+        goto exit;
+    }
+    ciphertext_len += len;
+
+    /* Reset */
+    EVP_CIPHER_CTX_reset(ctx);
+
+    /* import the key for decryption to pKey2 */
+    pKey2 = EVP_SKEY_import_raw_key(pLibCtx, pProvName, keyBuf.key, keyBuf.keyLen, NULL);
+    if (NULL == pKey2)
+    {
+        printf("ERROR EVP_SKEY_import_raw_key\n");
+        goto exit;        
+    }
+
+    if (1 != EVP_CipherInit_SKEY(ctx, pCipher, pKey2, pIv, ivLen, 0, NULL))
+    {
+        printf("ERROR EVP_CipherInit_SKEY\n");
+        goto exit;
+    }
+
+    if(1 != EVP_DecryptUpdate(ctx, decryptedtext, &len, ciphertext, ciphertext_len))
+    {
+        printf("ERROR EVP_DecryptUpdate\n");
+        goto exit;
+    }
+    decryptedtext_len = len;
+
+    if(1 != EVP_DecryptFinal_ex(ctx, decryptedtext + len, &len))
+    {
+        printf("ERROR EVP_DecryptFinal_ex\n");
+        goto exit;
+    }
+    decryptedtext_len += len;
+
+    status = DIGI_MEMCMP(decryptedtext, plaintext, (ubyte4) plaintext_len, &cmp);
+    if (OK != status)
+        goto exit;
+
+    if (0 != cmp)
+    {
+        printf("ERROR decrypted text did not match original plaintext\n");
+    }
+    else
+    {
+        ret = 0;
+    }
+
+exit:
+
+    if (NULL != ctx)
+    {
+        EVP_CIPHER_CTX_free(ctx);
+    }
+    if (NULL != pCipher)
+    {
+        EVP_CIPHER_free(pCipher);
+    }
+    if (NULL != pKey)
+    {
+        EVP_SKEY_free(pKey);
+    }
+    if (NULL != pKey2)
+    {
+        EVP_SKEY_free(pKey2);
     }
 
     return ret;

--- a/src/openssl_wrapper/versions/openssl-3.5.0/providers/digiprov.c
+++ b/src/openssl_wrapper/versions/openssl-3.5.0/providers/digiprov.c
@@ -212,6 +212,12 @@ static const OSSL_ALGORITHM digiprov_keymgmt[] = {
     { NULL, NULL, NULL }
 };
 
+static const OSSL_ALGORITHM digiprov_skeymgmt[] = {
+    { PROV_NAMES_AES, prov_name_fips, digiprov_aes_skeymgmt_functions},
+    { PROV_NAMES_GENERIC, prov_name_fips, digiprov_generic_skeymgmt_functions},
+    { NULL, NULL, NULL }
+};
+
 static const OSSL_ALGORITHM digiprov_signature[] = {
     { PROV_NAMES_RSA, prov_name_fips, digiprov_rsa_sig_functions},
     { PROV_NAMES_ECDSA, prov_name_fips, digiprov_ecdsa_functions},
@@ -360,6 +366,8 @@ static const OSSL_ALGORITHM* digiprov_provider_query(void *provCtx, int opId, in
             return digiprov_rands;
         case OSSL_OP_KEYMGMT:
             return digiprov_keymgmt;
+        case OSSL_OP_SKEYMGMT:
+            return digiprov_skeymgmt;
         case OSSL_OP_DECODER:
             return digiprov_decoder;
         case OSSL_OP_KEYEXCH:


### PR DESCRIPTION
…igiCert provider and extends the provider test, remove hash drbg from openssl connector for FIPS