### PR TITLE
DTM-9124: Add snap packaging for TrustEdge for Ubuntu Core

### DIFF
--- a/.github/workflows/trustedge_v2_localartifact.yml
+++ b/.github/workflows/trustedge_v2_localartifact.yml
@@ -5,6 +5,17 @@ on:
   workflow_dispatch: {}
   push:
     paths:
+      - scripts/ci/trustedge/**
+      - projects/trustedge/**
+      - src/common/**
+      - src/crypto/**
+      - src/mqtt/**
+      - src/ssl/**
+      - src/trustedge/**
+      - src/cert_enroll/**
+      - src/tap/**
+      - samples/mqtt_client/src/mqtt_client_example.c
+      - snap/**
       - .github/workflows/trustedge_v2_localartifact.yml
 
 env:
@@ -160,7 +171,9 @@ jobs:
 
       - name: Setup Certificate
         run: |
-          echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > ${{ github.workspace }}/Certificate_pkcs12.p12
+          printf '%s' "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > "${{ github.workspace }}/Certificate_pkcs12.p12"
+          chmod 600 "${{ github.workspace }}/Certificate_pkcs12.p12"
+
       - name: Set Variables
         id: variables
         run: |
@@ -180,7 +193,8 @@ jobs:
           chmod -R 755 ${{ github.workspace }}/gnupg_log
           chmod 755 ${{ github.workspace }}/ssm-scd
           ls -la
-          touch ${{ github.workspace }}/gnupg_log/gpg_agent_log
+          touch "${{ github.workspace }}/gnupg_log/gpg_agent_log"
+          chmod 644 "${{ github.workspace }}/gnupg_log/gpg_agent_log"
           ls -l ${{ github.workspace }}/gnupg_log
 
       - name: Setup GPG Agent, Download GPG Key from Signing Manager and Install dpkg-sig
@@ -193,6 +207,7 @@ jobs:
           pinentry-program /usr/bin/pinentry
           EOF
           rm -rf ${{ github.workspace }}/.gnupg/pubring.kbx
+          chmod 600 /home/runner/.gnupg/gpg-agent.conf
           chmod -R 755 ${{ github.workspace }}/smtools-linux-x64
           ls -l ${{ github.workspace }}/smtools-linux-x64
           gpgconf --kill all
@@ -256,4 +271,23 @@ jobs:
             MESSAGE="TrustEdge v2 Local Artifact failed on branch \`${GITHUB_REF_NAME}\`\nTriggered by: ${MENTION}\nRun: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           fi  
           curl -X POST -H 'Content-type: application/json' --data "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  Build_Snap:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+
+      - name: Build TrustEdge Snap
+        uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79  # v1
+        id: snapcraft
+
+      - name: Push Artifact - Snap Package
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: trustedge-snap
+          path: ${{ steps.snapcraft.outputs.snap }}
+          retention-days: ${{ github.ref_name == 'main' && 1 || 5 }}
 

--- a/.github/workflows/trustedge_v2_snap_publish.yml
+++ b/.github/workflows/trustedge_v2_snap_publish.yml
@@ -1,0 +1,101 @@
+# Publish TrustEdge Snap to Store
+#
+# This workflow publishes a previously built snap artifact to the Snap Store.
+#
+# Prerequisites:
+#   Add the SNAPCRAFT_STORE_CREDENTIALS secret to your repository:
+#   1. Install snapcraft: sudo snap install snapcraft --classic
+#   2. Login to your Ubuntu One account: snapcraft login
+#   3. Export credentials with restricted permissions:
+#      snapcraft export-login --snaps=trustedge --acls package_upload credentials.txt
+#   4. Copy contents of credentials.txt to GitHub secret SNAPCRAFT_STORE_CREDENTIALS
+#   5. Delete the local credentials.txt file
+#
+# Usage:
+#   1. Run the TrustEdge v2 Local Artifacts workflow to build the snap
+#   2. Copy the run ID from the workflow URL (e.g., github.com/.../actions/runs/<run_id>)
+#   3. Trigger this workflow manually with the run ID and desired channel
+
+name: Publish TrustEdge Snap to Store
+
+permissions:
+  contents: read
+  actions: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'Run ID of the build workflow to get snap artifact from (find in Actions URL)'
+        required: true
+        type: string
+      channel:
+        description: 'Snap Store channel to publish to'
+        required: true
+        default: 'edge'
+        type: choice
+        options:
+          - edge
+          - beta
+          - candidate
+          - stable
+
+jobs:
+  publish_snap:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download Snap Artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: trustedge-snap
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ inputs.run_id }}
+
+      - name: List downloaded files
+        run: |
+          echo "Downloaded snap files:"
+          ls -la *.snap
+
+      - name: Publish to Snap Store
+        uses: snapcore/action-publish@214b86e5ca036ead1668c79571f2af35adeb02a0  # v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        with:
+          snap: '*.snap'
+          release: ${{ inputs.channel }}
+
+      - name: Get Slack User ID
+        if: always()
+        id: slack_map
+        run: |
+          GITHUB_USER="${{ github.actor }}"
+          SLACK_USER_MAP='${{ vars.SLACK_USER_MAP_JSON }}'
+          
+          SLACK_USER_ID=$(echo "$SLACK_USER_MAP" | jq -r --arg user "$GITHUB_USER" '.[$user] // ""')
+          
+          echo "GitHub User: $GITHUB_USER"
+          echo "slack_user_id=$SLACK_USER_ID" >> $GITHUB_OUTPUT
+
+      - name: Send Slack notification (Success)
+        if: success()
+        run: |
+          SLACK_USER_ID="${{ steps.slack_map.outputs.slack_user_id }}"
+          if [ -n "$SLACK_USER_ID" ]; then
+            MENTION="<@$SLACK_USER_ID>"
+          else
+            MENTION="${GITHUB_ACTOR}"
+          fi
+          MESSAGE="TrustEdge Snap published to \`${{ inputs.channel }}\` channel by ${MENTION}\nRun: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          curl -X POST -H 'Content-type: application/json' --data "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Send Slack notification (Failure)
+        if: failure() || cancelled()
+        run: |
+          SLACK_USER_ID="${{ steps.slack_map.outputs.slack_user_id }}"
+          if [ -n "$SLACK_USER_ID" ]; then
+            MENTION="<@$SLACK_USER_ID>"
+          else
+            MENTION="${GITHUB_ACTOR}"
+          fi
+          MESSAGE="TrustEdge Snap publish to \`${{ inputs.channel }}\` failed\nTriggered by: ${MENTION}\nRun: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          curl -X POST -H 'Content-type: application/json' --data "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/projects/moctpm2_tools/provision/tpm2_provision_linux.sh
+++ b/projects/moctpm2_tools/provision/tpm2_provision_linux.sh
@@ -242,21 +242,26 @@ fi
 dbg_msg "Verifying that TPM2 device is available"
 [ -c "${DEVICE}" ] || quit "Device ${DEVICE} does not exist"
 
-dbg_msg "Setting '$TP_USER/$TP_GROUP' user/group device ownership for ${DEVICE}"
-cmd="chown $TP_USER:$TP_GROUP ${DEVICE}"
-execute_cmd "${cmd}"
-
-dbg_msg "Setting +rw group permissions for ${DEVICE}"
-cmd="chmod g+rw ${DEVICE}"
-execute_cmd "${cmd}"
-
-if [ -d /etc/udev/rules.d ]; then
-    dbg_msg "Updating /etc/udev/rules.d/71-tpm.rules"
-    echo "KERNEL==\"tpm0\", SUBSYSTEM==\"tpm\", MODE=\"0660\", OWNER=\"$TP_USER\", GROUP=\"$TP_GROUP\"" > /etc/udev/rules.d/71-tpm.rules
-
-    dbg_msg "Reloading udev rules to apply the permission changes to ${DEVICE}"
-    cmd='udevadm control --reload-rules && udevadm trigger'
+# Skip device ownership and udev rules in snap environment (snap's tpm plug handles access)
+if [[ -z "${SNAP}" ]]; then
+    dbg_msg "Setting '$TP_USER/$TP_GROUP' user/group device ownership for ${DEVICE}"
+    cmd="chown $TP_USER:$TP_GROUP ${DEVICE}"
     execute_cmd "${cmd}"
+
+    dbg_msg "Setting +rw group permissions for ${DEVICE}"
+    cmd="chmod g+rw ${DEVICE}"
+    execute_cmd "${cmd}"
+
+    if [ -d /etc/udev/rules.d ]; then
+        dbg_msg "Updating /etc/udev/rules.d/71-tpm.rules"
+        echo "KERNEL==\"tpm0\", SUBSYSTEM==\"tpm\", MODE=\"0660\", OWNER=\"$TP_USER\", GROUP=\"$TP_GROUP\"" > /etc/udev/rules.d/71-tpm.rules
+
+        dbg_msg "Reloading udev rules to apply the permission changes to ${DEVICE}"
+        cmd='udevadm control --reload-rules && udevadm trigger'
+        execute_cmd "${cmd}"
+    fi
+else
+    dbg_msg "Snap environment detected - skipping device ownership and udev rules (handled by tpm plug)"
 fi
 
 info_msg "Taking TPM2 ownership"

--- a/samples/trustedge/BUILD_RUN.md
+++ b/samples/trustedge/BUILD_RUN.md
@@ -99,6 +99,140 @@ After a successful Windows build:
 - The `trustedge.exe` executable will be located in `lib\`
 - The TrustEdge `.msi` installer will be located in `dist\`
 
+---
+
+## Snap Build
+
+TrustEdge can also be built and distributed as a snap package for easy installation across Linux distributions.
+
+> **Tip:** For detailed debugging, developer workflows, and troubleshooting confinement issues, see [snap/README.md](../../snap/README.md).
+
+### Prerequisites
+
+Install snapcraft:
+
+```bash
+sudo snap install snapcraft --classic
+```
+
+### Build the Snap
+
+Build the snap package from the repository root:
+
+```bash
+snapcraft
+```
+
+This will create a `trustedge_<version>_amd64.snap` file in the current directory.
+
+> **Note:** The build uses the same underlying build script (`ci_trustedge_build.sh`) with TPM2, CVC, proxy, and PQC support enabled.
+
+### Install from Snap Store
+
+Install TrustEdge from the Snap Store edge channel:
+
+```bash
+sudo snap install trustedge --edge
+```
+
+To update to the latest edge revision:
+
+```bash
+sudo snap refresh trustedge --edge
+```
+
+### Install a Locally Built Snap
+
+Install the locally built snap:
+
+```bash
+sudo snap install trustedge_*.snap --dangerous
+```
+
+> **Note:** The `--dangerous` flag is required for locally built snaps that are not signed by the Snap Store.
+
+### Connect Required Interfaces
+
+After installation, connect the necessary interfaces for full functionality:
+
+```bash
+sudo snap connect trustedge:tpm
+sudo snap connect trustedge:hardware-observe
+sudo snap connect trustedge:system-observe
+```
+
+### Verify Installation
+
+Check that TrustEdge snap is installed:
+
+```bash
+snap info trustedge
+trustedge --version
+```
+
+### Snap Service Management
+
+The snap includes a daemon service (`trustedged`) that is disabled by default:
+
+```bash
+# Enable and start the service
+sudo snap start --enable trustedge.trustedged
+
+# Check service status
+sudo snap services trustedge
+
+# Stop the service
+sudo snap stop trustedge.trustedged
+
+# Disable the service
+sudo snap stop --disable trustedge.trustedged
+```
+
+### Snap Directory Structure
+
+The snap organizes files across multiple directories:
+
+| Path | Contents |
+|------|----------|
+| `/snap/trustedge/current/usr/bin/trustedge` | Read-only binary |
+| `/var/snap/trustedge/common/digicert` | Writable configuration (persists across updates) |
+
+The layout maps `/etc/digicert` → `/var/snap/trustedge/common/digicert`, so the application sees standard paths.
+
+To view connected interfaces:
+
+```bash
+snap connections trustedge
+```
+
+### Provision TPM2 (Optional)
+
+If your device has a TPM2 and you want to use hardware-backed key storage, provision the TPM2 before bootstrapping:
+
+```bash
+# Connect the TPM interface
+sudo snap connect trustedge:tpm
+
+# Enter the snap shell and run the provisioning script
+sudo snap run --shell trustedge
+cd /etc/digicert/tpm2
+./provision_tpm2.sh --user root --group root
+```
+
+### Bootstrap with Snap
+
+Due to snap confinement, the bootstrap zip file must be placed in the snap's writable directory:
+
+```bash
+# Copy the bootstrap zip to the snap's writable directory
+sudo cp ./<guid>.zip /var/snap/trustedge/common/
+
+# Bootstrap the agent
+sudo trustedge agent --configure --bootstrap-zip /var/snap/trustedge/common/<guid>.zip
+```
+
+---
+
 ## Installation and Configuration
 
 ### Linux Package Installation
@@ -162,7 +296,7 @@ lib\trustedge.exe --version
 To run the locally built `trustedge` executable from any Command Prompt session without installing the MSI, add the repository `lib` directory to the current session `PATH`:
 
 ```cmd
-set PATH=%PATH%;C:\path\to\trustcore\lib
+set PATH=%PATH%;C:\path\to\trustcore-test\lib
 ```
 
 If you installed a downloaded MSI, you do not need to add the repository `lib` directory to `PATH`; use the installed TrustEdge location instead.

--- a/scripts/ci/devenv.sh
+++ b/scripts/ci/devenv.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# This script could be used to set environment variables on developer's system
+# prior to using the CI scripts. See README.md for additional information.
+#
+# WARNING: These variables will be automatically set on Jenkins, so DO NOT execute
+# this script on Jenkins as it might mess up build server's environment.
+
+function dev_env_die()
+{
+    printf "$@"
+    exit 255
+}
+
+function dev_env_main()
+{
+    local DEV_ENV_OLD_PWD="$(pwd)"
+
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+    export WORKSPACE=$( cd "${SCRIPT_DIR}/../.." ; pwd -P )
+    export BUILD_NUMBER='DEV'
+    export GIT_COMMIT=$( git rev-parse --short HEAD )
+
+    echo "WORKSPACE=${WORKSPACE}"
+    echo "BUILD_NUMBER=${BUILD_NUMBER}"
+    echo "GIT_COMMIT=${GIT_COMMIT}"
+
+    cd "${DEV_ENV_OLD_PWD}"
+}
+
+# ensure the script is running in main shell process
+echo $0 | grep -q devenv && dev_env_die "\nYou must source this script. For example:\n    $ source $0\n\n"
+
+dev_env_main

--- a/scripts/ci/trustedge/ci_trustedge_build.sh
+++ b/scripts/ci/trustedge/ci_trustedge_build.sh
@@ -73,6 +73,7 @@ function show_usage
     echo "Options:"
     echo "  --help                 - Show help options"
     echo "  --gdb                  - Build with debug symbols"
+    echo "  --debug-all            - Build all projects with --debug flag"
     echo "  --aes-gcm-4k           - Build with AES-GCM 4k table (rather than 256b default)"
     echo "  --aes-gcm-64k          - Build with AES-GCM 64k table (rather than 256b default)"
     echo "  --pkcs11-dynamic       - Build with dynamic loading for multiple pkcs11 libraries"
@@ -145,6 +146,10 @@ do
             ;;
         --gdb)
             BUILD_OPTIONS+=" --gdb"
+            ;;
+        --debug-all)
+            echo "Building all projects with --debug flag";
+            BUILD_OPTIONS+=" --debug"
             ;;
         --no-lib-rebuild)
             echo "NOT building supporting libraries.";

--- a/snap/README.md
+++ b/snap/README.md
@@ -1,0 +1,241 @@
+# TrustEdge Snap Package - Developer Guide
+
+This document covers debugging, developer workflows, and troubleshooting for the TrustEdge snap package. For basic build and installation instructions, see [samples/trustedge/BUILD_RUN.md](samples/trustedge/BUILD_RUN.md).
+
+## DEB to Snap Migration
+
+### Command Mapping
+
+| DEB Command | Snap Equivalent |
+|-------------|-----------------|
+| `sudo dpkg -i trustedge.deb` | `sudo snap install trustedge_*.snap --dangerous` |
+| `sudo dpkg -i trustedge.deb` (upgrade) | `sudo snap refresh trustedge` or `sudo snap install trustedge_*.snap --dangerous` |
+| `sudo dpkg --remove trustedge` | `sudo snap remove trustedge` |
+| `sudo dpkg --purge trustedge` | `sudo snap remove trustedge --purge` |
+
+### Data Path Mapping
+
+| DEB Path | Snap Path | Description |
+|----------|-----------|-------------|
+| `/etc/digicert/` | `/var/snap/trustedge/common/digicert/` | Configuration directory |
+| `/etc/digicert/conf/` | `/var/snap/trustedge/common/digicert/conf/` | Config files |
+| `/etc/digicert/keystore/` | `/var/snap/trustedge/common/digicert/keystore/` | Certificate keystore |
+| `/var/lib/trustedge/` | `/var/snap/trustedge/current/trustedge/` | Runtime data |
+| `/usr/bin/trustedge` | `/snap/bin/trustedge` | Binary location |
+
+### Hook Lifecycle (matches DEB behavior)
+
+| DEB Script | Snap Hook | Description |
+|------------|-----------|-------------|
+| `preinst` | - | EULA handled differently (snap store or skip) |
+| `postinst` (install) | `install` | Create directories, copy default config |
+| `postinst` (upgrade) | `post-refresh` | Restore config, update version files |
+| `prerm` (upgrade) | `pre-refresh` | Backup configuration before upgrade |
+| `prerm` (remove) | `remove` | Backup configuration to /tmp |
+| `postrm` (purge) | `--purge` flag | Removes all data including $SNAP_COMMON |
+| `postrm` (remove) | - | Config preserved in $SNAP_COMMON (one snapshot kept) |
+
+---
+
+## Developer Workflows
+
+### Build Options
+
+```bash
+# Standard build
+snapcraft
+
+# Build with LXD (recommended for clean environment)
+snapcraft --use-lxd
+
+# Build for debugging (drops into shell on failure)
+snapcraft --debug
+
+# Clean build (removes previous build artifacts)
+snapcraft clean
+snapcraft
+
+# Build with verbose output
+snapcraft --verbosity=verbose
+
+# Build without cleanup (faster iteration, use with caution)
+snapcraft --destructive-mode
+```
+
+### Inspecting the Built Snap
+
+```bash
+# List snap contents
+unsquashfs -l trustedge_*.snap
+
+# Extract snap for inspection
+unsquashfs trustedge_*.snap -d snap-contents/
+
+# Check the binary
+ls -la snap-contents/usr/bin/
+```
+
+### Testing Snap Locally
+
+```bash
+# Install with dangerous flag (for unsigned local snaps)
+sudo snap install trustedge_*.snap --dangerous
+
+# Reinstall after rebuilding
+sudo snap remove trustedge
+sudo snap install trustedge_*.snap --dangerous
+```
+
+### Inspecting Snap Environment
+
+```bash
+# Run a shell inside the snap's confinement
+sudo snap run --shell trustedge
+
+# Check environment variables
+snap run --shell trustedge -c 'env | grep SNAP'
+
+# Verify paths
+snap run --shell trustedge -c 'ls -la /etc/digicert'
+```
+
+### Checking Snap Version and Info
+
+```bash
+# Installed version
+snap info trustedge
+
+# Detailed revision info
+snap list trustedge --all
+
+# Check snap assertions
+snap known snap-declaration snap-name=trustedge
+```
+
+### Service Management
+
+```bash
+# View service status
+sudo snap services trustedge
+
+# Enable/disable the daemon
+sudo snap start --enable trustedge.trustedged
+sudo snap stop --disable trustedge.trustedged
+
+# Restart after config changes
+sudo snap restart trustedge.trustedged
+
+# Check service logs
+sudo snap logs trustedge.trustedged -n=50
+```
+
+### Cleaning Up
+
+```bash
+# Remove snap but keep data (default)
+sudo snap remove trustedge
+
+# Remove snap and all data
+sudo snap remove trustedge --purge
+
+# Clean snapcraft build artifacts
+snapcraft clean
+```
+
+---
+
+## Troubleshooting
+
+### Check Interface Connections
+
+```bash
+# View connected interfaces
+snap connections trustedge
+
+# List all available interfaces
+snap interfaces
+
+# Check specific interface status
+snap interface tpm
+```
+
+### File Access Issues (Confinement)
+
+Snaps cannot access arbitrary files on the host. To pass files to the snap:
+
+```bash
+# Copy files to the snap's writable directory
+sudo cp ./bootstrap.zip /var/snap/trustedge/common/
+
+# Reference them using the snap path
+sudo trustedge agent --configure --bootstrap-zip /var/snap/trustedge/common/bootstrap.zip
+```
+
+### View Detailed Logs
+
+```bash
+# Service logs
+sudo journalctl -u snap.trustedge.trustedged.service -f
+
+# All snap logs
+sudo snap logs trustedge -f
+
+# Logs with timestamps
+sudo snap logs trustedge -n=100
+```
+
+### Enable Debug Logging
+
+Edit the TrustEdge configuration:
+
+```bash
+sudo nano /var/snap/trustedge/common/digicert/trustedge.json
+```
+
+Set `"logLevel": "DEBUG"` and restart the service.
+
+### Running in Devmode (Bypasses Confinement)
+
+For debugging confinement issues:
+
+```bash
+sudo snap install trustedge_*.snap --dangerous --devmode
+```
+
+### Debugging Confinement Denials
+
+```bash
+# Watch for AppArmor denials in real-time
+sudo journalctl -k | grep DENIED
+
+# Or use snappy-debug (install if needed: sudo snap install snappy-debug)
+sudo snappy-debug
+```
+
+---
+
+## Features Included
+
+This snap build includes:
+- **TPM2 Support** - Hardware-backed key storage
+- **PQC Support** - Post-Quantum Cryptography
+- **PQC Composite** - PQC composite certificates
+- **Proxy Support** - HTTP/HTTPS proxy configuration
+- **CVC Support** - CV Certificate handling
+- **EST/SCEP** - Enrollment protocols
+
+## Directory Layout
+
+The snap uses the following layout:
+
+| Snap Path | Mapped To |
+|-----------|-----------|
+| `$SNAP_COMMON/digicert` | `/etc/digicert` |
+| `$SNAP_DATA/trustedge` | `/var/lib/trustedge` |
+
+## Architecture Support
+
+Currently supported:
+- amd64 (x86_64)
+
+For ARM builds, modify the `platforms` section in `snapcraft.yaml`.

--- a/snap/README.md
+++ b/snap/README.md
@@ -1,6 +1,6 @@
 # TrustEdge Snap Package - Developer Guide
 
-This document covers debugging, developer workflows, and troubleshooting for the TrustEdge snap package. For basic build and installation instructions, see [samples/trustedge/BUILD_RUN.md](samples/trustedge/BUILD_RUN.md).
+This document covers debugging, developer workflows, and troubleshooting for the TrustEdge snap package. For basic build and installation instructions, see [samples/trustedge/BUILD_RUN.md](../samples/trustedge/BUILD_RUN.md).
 
 ## DEB to Snap Migration
 

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,24 @@
+#!/bin/bash
+# TrustEdge snap install hook
+# Runs once when snap is first installed
+
+set -e
+
+echo "Initializing TrustEdge configuration..."
+
+# Create writable config directory structure
+mkdir -p "$SNAP_COMMON/digicert"
+
+# Copy default configuration from snap to writable location
+if [ -d "$SNAP/etc/digicert" ]; then
+    cp -r "$SNAP/etc/digicert/"* "$SNAP_COMMON/digicert/"
+    echo "Configuration initialized at $SNAP_COMMON/digicert"
+fi
+
+# Ensure proper permissions (matching DEB installation)
+chmod 775 "$SNAP_COMMON/digicert"
+chmod 775 "$SNAP_COMMON/digicert/conf" 2>/dev/null || true
+chmod 775 "$SNAP_COMMON/digicert/keystore" 2>/dev/null || true
+chmod -R 775 "$SNAP_COMMON/digicert/keystore/"* 2>/dev/null || true
+
+echo "TrustEdge installation complete"

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -11,7 +11,7 @@ mkdir -p "$SNAP_COMMON/digicert"
 
 # Copy default configuration from snap to writable location
 if [ -d "$SNAP/etc/digicert" ]; then
-    cp -r "$SNAP/etc/digicert/"* "$SNAP_COMMON/digicert/"
+    cp -a "$SNAP/etc/digicert/." "$SNAP_COMMON/digicert/"
     echo "Configuration initialized at $SNAP_COMMON/digicert"
 fi
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,263 @@
+name: trustedge
+adopt-info: trustedge
+summary: IoT device management and security command-line tool
+description: |
+  TrustEdge is built on DigiCert TrustCore SDK and provides device
+  management and security operations. It can also interact with a
+  device's secure hardware elements (TPM or TEE).
+
+  Commands:
+  - agent: Manages interaction with DigiCert Device Trust Manager
+    (bootstrap, configuration, device updates)
+  - certificate: Generates and manages keys, creates CSRs, and
+    supports x.509 certificate generation and renewal
+  - mqtt: Publishes and subscribes to MQTT topics using x.509
+    authentication
+
+  For complete documentation, visit:
+  https://dev.digicert.com/en/trustedge.html
+
+base: core24
+grade: devel
+confinement: strict
+
+platforms:
+  amd64:
+    build-on: [amd64]
+    build-for: [amd64]
+
+# Suppress lint warnings for statically linked binary
+lint:
+  ignore:
+    - library  # Monolithic build statically links libraries
+
+# Layout to match expected installation paths
+layout:
+  /etc/digicert:
+    bind: $SNAP_COMMON/digicert
+  /var/lib/trustedge:
+    bind: $SNAP_DATA/trustedge
+
+apps:
+  trustedge:
+    # CLI tool for manual user interaction
+    command: usr/bin/trustedge
+    plugs:
+      - network
+      - network-bind
+      - tpm
+      - hardware-observe
+      - system-observe
+      - log-observe
+      - shared-memory
+      - posix-mq
+  trustedged:
+    # Background service (daemon) - disabled by default; enable with `snap start --enable trustedge.trustedged`
+    command: usr/bin/trustedge --daemon
+    daemon: simple
+    install-mode: disable
+    restart-condition: always
+    restart-delay: 60s
+    stop-timeout: 60s
+    plugs:
+      - network
+      - network-bind
+      - tpm
+      - hardware-observe
+      - system-observe
+      - log-observe
+      - shared-memory
+      - posix-mq
+
+plugs:
+  # TPM2 access for secure key storage
+  tpm:
+    interface: tpm
+  # Shared memory for POSIX semaphores (/dev/shm)
+  shared-memory:
+    private: true
+
+parts:
+  trustedge:
+    plugin: nil
+    source: .
+    build-packages:
+      - build-essential
+      - cmake
+      - git
+    override-build: |
+      # Set up build environment
+      export CMAKE_DIR=/usr
+      export PATH=$CMAKE_DIR/bin:$PATH
+      
+      # Extract version from git tags (replicating paulhatch/semantic-version)
+      # Matches GitHub workflow: tag_prefix="trustedge_", version_format="${major}.${minor}.${patch}-${increment}"
+      cd ${CRAFT_PART_SRC}
+      
+      # Find the latest version tag (sorted by version number, not date)
+      LATEST_TAG=$(git tag -l "trustedge_*" | sort -t '_' -k2 -V | tail -n 1)
+      if [ -z "$LATEST_TAG" ]; then
+        LATEST_TAG="trustedge_0.0.0"
+      fi
+      
+      # Extract version base (e.g., "1.2.3" from "trustedge_1.2.3")
+      VERSION_BASE=$(echo "$LATEST_TAG" | sed 's/trustedge_//')
+      
+      # Count commits since the tag (this is the ${increment} in paulhatch/semantic-version)
+      TAG_COMMIT=$(git rev-list -n 1 "$LATEST_TAG" 2>/dev/null || echo "")
+      if [ -n "$TAG_COMMIT" ]; then
+        COMMITS_SINCE=$(git rev-list --count ${TAG_COMMIT}..HEAD 2>/dev/null || echo "0")
+      else
+        COMMITS_SINCE=$(git rev-list --count HEAD 2>/dev/null || echo "0")
+      fi
+      
+      # Format: major.minor.patch-increment (matches paulhatch version_format)
+      if [ "$COMMITS_SINCE" -gt 0 ]; then
+        SNAP_VERSION="${VERSION_BASE}-${COMMITS_SINCE}"
+      else
+        SNAP_VERSION="${VERSION_BASE}"
+      fi
+      
+      # Set the snap version dynamically
+      craftctl set version="${SNAP_VERSION}"
+      echo "Building TrustEdge version: ${SNAP_VERSION}"
+      
+      # Using the same build process as CI
+      ./scripts/ci/trustedge/ci_trustedge_build.sh \
+        --version-string ${SNAP_VERSION} \
+        --monolithic \
+        --tpm2 \
+        --cvc \
+        --proxy \
+        --pqc \
+        --pqc-composite \
+        --enable-pc
+
+      # Install the binary
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/bin
+      cp ${CRAFT_PART_SRC}/bin/trustedge ${CRAFT_PART_INSTALL}/usr/bin/
+      chmod 755 ${CRAFT_PART_INSTALL}/usr/bin/trustedge
+      
+      # Install configuration files - match DEB structure exactly
+      DIGICERT_DIR=${CRAFT_PART_INSTALL}/etc/digicert
+      mkdir -p ${DIGICERT_DIR}/cloudprovider
+      mkdir -p ${DIGICERT_DIR}/conf
+      mkdir -p ${DIGICERT_DIR}/keystore/ca
+      mkdir -p ${DIGICERT_DIR}/keystore/certs
+      mkdir -p ${DIGICERT_DIR}/keystore/conf
+      mkdir -p ${DIGICERT_DIR}/keystore/crls
+      mkdir -p ${DIGICERT_DIR}/keystore/keys
+      mkdir -p ${DIGICERT_DIR}/keystore/psks
+      mkdir -p ${DIGICERT_DIR}/keystore/req
+      mkdir -p ${DIGICERT_DIR}/scripts
+      mkdir -p ${DIGICERT_DIR}/service/completed
+      mkdir -p ${DIGICERT_DIR}/service/failed
+      mkdir -p ${DIGICERT_DIR}/service/processing
+      mkdir -p ${DIGICERT_DIR}/service/request
+      
+      # Copy trustedge.json to root level
+      cp ${CRAFT_PART_SRC}/projects/trustedge/installer/DEB/config/trustedge.json ${DIGICERT_DIR}/ 2>/dev/null || true
+      
+      # Copy eula.txt to conf
+      cp ${CRAFT_PART_SRC}/projects/trustedge/eula.txt ${DIGICERT_DIR}/conf/ 2>/dev/null || true
+      
+      # Create version.txt with snap version
+      echo "${SNAP_VERSION}" > ${DIGICERT_DIR}/conf/version.txt
+      
+      # Copy scripts
+      cp ${CRAFT_PART_SRC}/projects/trustedge/packaging/DEB/configure_trustedge.sh \
+         ${DIGICERT_DIR}/scripts/ 2>/dev/null || true
+      cp ${CRAFT_PART_SRC}/projects/trustedge/packaging/DEB/start_trustedge.sh \
+         ${DIGICERT_DIR}/scripts/ 2>/dev/null || true
+      cp ${CRAFT_PART_SRC}/projects/trustedge/packaging/DEB/trustedge.service \
+         ${DIGICERT_DIR}/scripts/ 2>/dev/null || true
+      
+      # Set permissions to match DEB installation
+      # Directories with group write (775)
+      chmod 775 ${DIGICERT_DIR}
+      chmod 775 ${DIGICERT_DIR}/conf
+      chmod 775 ${DIGICERT_DIR}/keystore
+      chmod 775 ${DIGICERT_DIR}/keystore/ca
+      chmod 775 ${DIGICERT_DIR}/keystore/certs
+      chmod 775 ${DIGICERT_DIR}/keystore/conf
+      chmod 775 ${DIGICERT_DIR}/keystore/crls
+      chmod 775 ${DIGICERT_DIR}/keystore/keys
+      chmod 775 ${DIGICERT_DIR}/keystore/psks
+      chmod 775 ${DIGICERT_DIR}/keystore/req
+      
+      # Directories without group write (755)
+      chmod 755 ${DIGICERT_DIR}/cloudprovider
+      chmod 755 ${DIGICERT_DIR}/scripts
+      chmod 755 ${DIGICERT_DIR}/service
+      chmod 755 ${DIGICERT_DIR}/service/completed
+      chmod 755 ${DIGICERT_DIR}/service/failed
+      chmod 755 ${DIGICERT_DIR}/service/processing
+      chmod 755 ${DIGICERT_DIR}/service/request
+      
+      # Executable scripts (755)
+      chmod 755 ${DIGICERT_DIR}/scripts/configure_trustedge.sh
+      chmod 755 ${DIGICERT_DIR}/scripts/start_trustedge.sh
+      
+      # Non-executable files (644)
+      chmod 644 ${DIGICERT_DIR}/trustedge.json
+      chmod 644 ${DIGICERT_DIR}/scripts/trustedge.service
+      
+      # Config files with group write (664)
+      chmod 664 ${DIGICERT_DIR}/conf/eula.txt
+      chmod 664 ${DIGICERT_DIR}/conf/version.txt
+  tpm2-tools:
+    plugin: nil
+    source: .
+    build-packages:
+      - build-essential
+      - cmake
+      - zip
+      - unzip
+    override-build: |
+      # Set up build environment
+      export CMAKE_DIR=/usr
+      export PATH=$CMAKE_DIR/bin:$PATH
+      
+      # Build TPM2 tools (produces dist/tpm2_tools-*.zip)
+      cd ${CRAFT_PART_SRC}
+
+      echo "Building TPM2 tools for TrustEdge"
+      
+      # Using the same build process as CI
+      ./scripts/ci/trustedge/build_trustedge_tools.sh
+      
+      # Install configuration files - match DEB structure exactly
+      DIGICERT_DIR=${CRAFT_PART_INSTALL}/etc/digicert
+      TPM2_DIR=${DIGICERT_DIR}/tpm2
+      mkdir -p ${TPM2_DIR}
+
+      # Extract the built TPM2 tools zip file and place the contents in the snap
+      unzip -o ${CRAFT_PART_SRC}/dist/tpm2_tools-*.zip -d ${TPM2_DIR}
+
+      
+      # Set permissions for TPM2 tools directory and files
+      # Directories with group write (775)
+      chmod 775 ${TPM2_DIR}
+      chmod 775 ${TPM2_DIR}/bin
+      chmod 775 ${TPM2_DIR}/conf
+      chmod 775 ${TPM2_DIR}/conf/tap
+      chmod 775 ${TPM2_DIR}/conf/tap/tpm2
+
+      # Directories without group write (755)
+      chmod 755 ${TPM2_DIR}/scripts
+      chmod 755 ${TPM2_DIR}/scripts/tap
+      chmod 755 ${TPM2_DIR}/scripts/tap/tpm2
+
+      # Executable binaries (755)
+      chmod 755 ${TPM2_DIR}/bin/*
+      
+      # Executable scripts (755)
+      chmod 755 ${TPM2_DIR}/provision_tpm2.sh
+      chmod 755 ${TPM2_DIR}/reset_tpm2.sh
+      chmod 755 ${TPM2_DIR}/scripts/tap/tpm2/tpm2_provision_linux.sh
+      chmod 755 ${TPM2_DIR}/scripts/tap/tpm2/tpm2_reset_linux.sh
+      
+      # Non-executable files (644)
+      chmod 644 ${TPM2_DIR}/conf/tap/tpm2/tpm2_prov.conf
+      chmod 644 ${TPM2_DIR}/conf/tap/tpm2/tpm2_prov.conf.tmpl
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -156,21 +156,21 @@ parts:
       mkdir -p ${DIGICERT_DIR}/service/request
       
       # Copy trustedge.json to root level
-      cp ${CRAFT_PART_SRC}/projects/trustedge/installer/DEB/config/trustedge.json ${DIGICERT_DIR}/ 2>/dev/null || true
+      cp ${CRAFT_PART_SRC}/projects/trustedge/installer/DEB/config/trustedge.json ${DIGICERT_DIR}/
       
       # Copy eula.txt to conf
-      cp ${CRAFT_PART_SRC}/projects/trustedge/eula.txt ${DIGICERT_DIR}/conf/ 2>/dev/null || true
+      cp ${CRAFT_PART_SRC}/projects/trustedge/eula.txt ${DIGICERT_DIR}/conf/
       
       # Create version.txt with snap version
       echo "${SNAP_VERSION}" > ${DIGICERT_DIR}/conf/version.txt
       
       # Copy scripts
       cp ${CRAFT_PART_SRC}/projects/trustedge/packaging/DEB/configure_trustedge.sh \
-         ${DIGICERT_DIR}/scripts/ 2>/dev/null || true
+         ${DIGICERT_DIR}/scripts/
       cp ${CRAFT_PART_SRC}/projects/trustedge/packaging/DEB/start_trustedge.sh \
-         ${DIGICERT_DIR}/scripts/ 2>/dev/null || true
+         ${DIGICERT_DIR}/scripts/
       cp ${CRAFT_PART_SRC}/projects/trustedge/packaging/DEB/trustedge.service \
-         ${DIGICERT_DIR}/scripts/ 2>/dev/null || true
+         ${DIGICERT_DIR}/scripts/
       
       # Set permissions to match DEB installation
       # Directories with group write (775)


### PR DESCRIPTION
- Add snap/snapcraft.yaml with TrustEdge build configuration
  - Configure base (core24), parts, and apps
  - Enable tpm interface for /dev/tpm0 access
  - Use SNAP_DATA/SNAP_COMMON for config instead of /etc
- Add snap/README.md with packaging documentation
- Add snap/hooks/install for post-install setup
- Add trustedge_v2_snap_publish.yml GitHub workflow
- Update trustedge_v2_localartifact.yml with snap build steps
- Update tpm2_provision_linux.sh for snap environment
- Update BUILD_RUN.md with snap installation instructions