### PR TITLE
TRUSTCORE: Change pkcs5 salt len to 16

### DIFF
--- a/scripts/openssl/openssl-3.0.7/include/openssl/evp.h.patch
+++ b/scripts/openssl/openssl-3.0.7/include/openssl/evp.h.patch
@@ -1,0 +1,4 @@
+39c39
+< # define PKCS5_SALT_LEN                  8
+---
+> # define PKCS5_SALT_LEN                  16


### PR DESCRIPTION
[OpenSSLConnectorUnitTest (3.0.7)](https://github.com/digicert/trustcore-test/actions/runs/30108636794/job/89532244162?pr=316) seems to have passed fine. The codeQL issues should not be related to this change of course. So posting the PR here too.